### PR TITLE
ci: restrict workflow triggers to main branch only

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -87,7 +87,7 @@ jobs:
   container:
     runs-on: ubuntu-latest
     needs: [ lint, test ]
-    if: github.event_name == 'push' || github.event_name == 'release'
+    if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'release'
     strategy:
       matrix:
         mode: [ slim, debug ]

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -2,7 +2,7 @@ name: Test, Build and Release
 
 on:
   push:
-    branches: [ '*' ]
+    branches: [ main ]
     paths:
     - '**.go'
     - 'go.mod'
@@ -12,7 +12,7 @@ on:
     - 'scripts/build.sh'
     - '.github/workflows/test-build-release.yml'
   pull_request:
-    branches: [ '*' ]
+    branches: [ main ]
     paths:
     - '**.go'
     - 'go.mod'

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -2,17 +2,7 @@ name: Test, Build and Release
 
 on:
   push:
-    branches: [ main ]
-    paths:
-    - '**.go'
-    - 'go.mod'
-    - 'go.sum'
-    - 'Dockerfile'
-    - '.dockerignore'
-    - 'scripts/build.sh'
-    - '.github/workflows/test-build-release.yml'
-  pull_request:
-    branches: [ main ]
+    branches: [ '**' ]
     paths:
     - '**.go'
     - 'go.mod'
@@ -87,7 +77,7 @@ jobs:
   container:
     runs-on: ubuntu-latest
     needs: [ lint, test ]
-    if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'release'
+    if: github.event_name == 'push' || github.event_name == 'release'
     strategy:
       matrix:
         mode: [ slim, debug ]
@@ -115,8 +105,8 @@ jobs:
       with:
         images: ghcr.io/${{ github.repository }}
         tags: |
-          type=raw,value={{branch}},enable=${{ github.event_name != 'release' && matrix.mode == 'slim' }}
-          type=raw,value={{branch}}-debug,enable=${{ github.event_name != 'release' && matrix.mode == 'debug' }}
+          type=raw,value={{branch}},enable=${{ github.event_name == 'push' && matrix.mode == 'slim' }}
+          type=raw,value={{branch}}-debug,enable=${{ github.event_name == 'push' && matrix.mode == 'debug' }}
           type=raw,value={{tag}},enable=${{ github.event_name == 'release' && matrix.mode == 'slim' }}
           type=raw,value={{tag}}-debug,enable=${{ github.event_name == 'release' && matrix.mode == 'debug' }}
           type=raw,value=latest,enable=${{ github.event_name == 'release' && matrix.mode == 'slim' }}


### PR DESCRIPTION
Limit push and pull_request event triggers in the test-build-release workflow from wildcard (`*`) to `main` only, avoiding unnecessary pipeline runs on feature branches.